### PR TITLE
feat: Refactor slug creation for Markdown and Sanity posts

### DIFF
--- a/src/components/bio.js
+++ b/src/components/bio.js
@@ -18,9 +18,6 @@ const Bio = () => {
             name
             summary
           }
-          social {
-            twitter
-          }
         }
       }
     }
@@ -28,7 +25,6 @@ const Bio = () => {
 
   // Set these values by editing "siteMetadata" in gatsby-config.js
   const author = data.site.siteMetadata?.author
-  const social = data.site.siteMetadata?.social
 
   return (
     <div className="bio">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,11 +8,7 @@ import Seo from "../components/seo"
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const blogPosts = data.allMarkdownRemark.nodes
-  const sanityPosts = data.allSanityPost.nodes.map(post => ({
-    ...post,
-    path: `/sanity-post/${post.slug.current}`,
-    excerpt: post.title,
-  }))
+  const sanityPosts = data.allSanityPost.nodes
 
   const posts = [...sanityPosts, ...blogPosts]
 
@@ -35,10 +31,9 @@ const BlogIndex = ({ data, location }) => {
       <ol style={{ listStyle: `none` }}>
         {posts.map(post => {
           const title =
-            post.frontmatter?.title || post.fields?.slug || post.title
-
+            post.frontmatter?.title || post.title || post.fields?.slug
           return (
-            <li key={post.fields?.slug || post.slug.current}>
+            <li key={post.fields.slug}>
               <article
                 className="post-list-item"
                 itemScope
@@ -46,7 +41,7 @@ const BlogIndex = ({ data, location }) => {
               >
                 <header>
                   <h2>
-                    <Link to={post.fields?.slug || post.path} itemProp="url">
+                    <Link to={post.fields.slug} itemProp="url">
                       <span itemProp="headline">{title}</span>
                     </Link>
                   </h2>
@@ -103,8 +98,8 @@ export const pageQuery = graphql`
         id
         publishedAt(formatString: "MMMM DD, YYYY")
         title
-        slug {
-          current
+        fields {
+          slug
         }
       }
     }

--- a/src/templates/sanity-post.js
+++ b/src/templates/sanity-post.js
@@ -43,14 +43,14 @@ const SanityPostTemplate = ({
         >
           <li>
             {previous && (
-              <Link to={`/sanity-post/${previous.slug.current}`} rel="prev">
+              <Link to={previous.fields.slug} rel="prev">
                 ← {previous.title}
               </Link>
             )}
           </li>
           <li>
             {next && (
-              <Link to={`/sanity-post/${next.slug.current}`} rel="next">
+              <Link to={next.fields.slug} rel="next">
                 {next.title} →
               </Link>
             )}
@@ -86,14 +86,14 @@ export const pageQuery = graphql`
     }
     previous: sanityPost(id: { eq: $previousPostId }) {
       title
-      slug {
-        current
+      fields {
+        slug
       }
     }
     next: sanityPost(id: { eq: $nextPostId }) {
       title
-      slug {
-        current
+      fields {
+        slug
       }
     }
   }


### PR DESCRIPTION
This commit refactors the slug creation process for Markdown and Sanity posts. It updates the `gatsby-node.js` file to create slugs for Markdown posts in the format `/blog-post/my-post` and for Sanity posts in the format `/sanity-post/my-post/`. This change improves the consistency and readability of the generated slugs.

Recent user commits:
- feat: add sanity source
- feat: upgrade dependencies
- edit: upgrade gatsby starter

Recent repository commits:
- feat: add sanity source
- feat: upgrade dependencies
- edit: upgrade gatsby starter