### PR TITLE
feat: Update draft status for blog posts

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -2,6 +2,7 @@
 title: Hello World
 date: "2015-05-01T22:12:03.284Z"
 description: "Hello World"
+isDraft: true
 ---
 
 This is my first post on my new fake blog! How exciting!

--- a/content/blog/my-second-post/index.md
+++ b/content/blog/my-second-post/index.md
@@ -1,6 +1,7 @@
 ---
 title: My Second Post!
 date: "2015-05-06T23:46:37.121Z"
+isDraft: true
 ---
 
 Wow! I love blogging so much already.

--- a/content/blog/new-beginnings/index.md
+++ b/content/blog/new-beginnings/index.md
@@ -2,6 +2,7 @@
 title: New Beginnings
 date: "2015-05-28T22:40:32.169Z"
 description: This is a custom description for SEO and Open Graph purposes, rather than the default generated excerpt. Simply add a description field to the frontmatter.
+isDraft: true
 ---
 
 Far far away, behind the word mountains, far from the countries Vokalia and

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -80,7 +80,10 @@ export const pageQuery = graphql`
         title
       }
     }
-    allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
+    allMarkdownRemark(
+      sort: { frontmatter: { date: DESC } }
+      filter: { frontmatter: { isDraft: { ne: true } } }
+    ) {
       nodes {
         excerpt
         fields {
@@ -90,6 +93,7 @@ export const pageQuery = graphql`
           date(formatString: "MMMM DD, YYYY")
           title
           description
+          isDraft
         }
       }
     }


### PR DESCRIPTION
This commit updates the draft status for three blog posts: "Hello World", "My Second Post!", and "New Beginnings". The `isDraft` property is set to `true` for these posts in the Markdown frontmatter, indicating that they are still in draft mode and should not be published. This change ensures that the draft posts are properly handled and not included in the published blog pages.

Recent repository commits:
- feat: Refactor slug creation for Markdown and Sanity posts
- feat: add sanity source
- feat: upgrade dependencies
- edit: upgrade gatsby starter